### PR TITLE
Create unique metadata per text file

### DIFF
--- a/backend/src/routers/rest.ts
+++ b/backend/src/routers/rest.ts
@@ -21,11 +21,10 @@ const createRestRouter = (isProduction: boolean) => {
             const id = decodeURIComponent(req.headers.id as string);
             const show = decodeURIComponent(req.headers.show as string);
             if (file.fieldname == 'script') {
-                //TODO: don't assume .txt
                 cb(null, id);
                 console.log('uploading file: ' + id);
             } else if (file.fieldname == 'metadata') {
-                cb(null, show + '.json');
+                cb(null, 'metadata-' + id + '.json');
             }
         },
     });

--- a/frontend/src/components/frontpage/index.tsx
+++ b/frontend/src/components/frontpage/index.tsx
@@ -102,7 +102,7 @@ class FrontPage extends React.Component<Props, State> {
         console.log('sending the file now');
         // TODO: verify formData;
         const podcastId = this.state.podcastType;
-        const rssFeed = 'https://url.html';
+        const rssFeed = 'https://hlekkurinn.is';
         this.verifyFormData();
         if (this.state.selectedFiles != null && podcastId != null) {
             console.log(this.state.selectedFiles);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -20,7 +20,7 @@ export const uploadFile = async (
     const jsonString = JSON.stringify({
         show_id: show,
         audio_feed: rssFeed,
-        file_type: file.type,
+        file_name: file.name,
     });
 
     const metadata = new Blob([jsonString], {


### PR DESCRIPTION
Previously each show had the same metadata filename per episode. Now each metadata file is named after the episode and the metadata contains the show id and the episode name etc.

This makes it less likely that a file will be written over across shows or within the same show.