### PR TITLE
Filelist hide audio

### DIFF
--- a/frontend/src/components/frontpage/audio_selection.tsx
+++ b/frontend/src/components/frontpage/audio_selection.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import Form from 'react-bootstrap/Form';
+import TextInput from '../ui/input/text-input';
+
+const RadioButtonsContainer = styled.div`
+    margin-top: 1rem;
+`;
+
+const UploadTypeText = styled.p`
+    margin: 0;
+`;
+
+const RadioLabel = styled.label`
+    margin-left: 0.5rem;
+`;
+
+const UrlInput = styled(TextInput)`
+    margin: 1rem 0rem;
+`;
+
+export enum AudioType {
+    RSS = 'rss',
+    AUDIO_FILES = 'audio_files',
+    NONE = 'none',
+}
+
+interface AudioSelectionProps {
+    onAudioFilesChanged: (event: any) => void;
+    onFeedChange: (event: any) => void;
+    onAudioTypeChanged: (event: any) => void;
+}
+
+export const AudioSelection: React.FunctionComponent<AudioSelectionProps> = (
+    props
+) => {
+    const [audioFiles, setAudioFiles] = React.useState<File[]>([]);
+    const [audioType, setAudioType] = React.useState<AudioType>(AudioType.NONE);
+    const [feed, setFeed] = React.useState('');
+
+    const handleRadioButton = (input: AudioType) => {
+        setAudioType(input);
+    };
+
+    const feedChanged = (event: any) => {
+        setFeed(event.target.value);
+        props.onFeedChange(event);
+    };
+
+    return (
+        <>
+            <h3>Hljóðskrár</h3>
+            <RadioButtonsContainer>
+                <UploadTypeText>
+                    Veldu hvernig þú vilt gefa hljóðskrár. RSS hlekkur eða
+                    hlaðið upp hljóðskrár.
+                </UploadTypeText>
+                <input
+                    type="radio"
+                    id="rss"
+                    name="audio_type"
+                    value="rss"
+                    onChange={() => handleRadioButton(AudioType.RSS)}
+                    checked={audioType == AudioType.RSS}
+                ></input>
+                <RadioLabel htmlFor="rss">RSSFeed hlekkur</RadioLabel>
+                <br />
+                <input
+                    type="radio"
+                    id="audio_files"
+                    name="audio_type"
+                    value="audio_files"
+                    onChange={() => handleRadioButton(AudioType.AUDIO_FILES)}
+                    checked={audioType == AudioType.AUDIO_FILES}
+                ></input>
+                <RadioLabel htmlFor="audio_files">Hljóðskrár</RadioLabel>
+            </RadioButtonsContainer>
+            {audioFiles ? (
+                <Form.Group controlId="formFileMultipleAudio" className="mb-3">
+                    <Form.Label>
+                        Veldu hljóðskrár til að hlaða upp (hljóðskrár á sniði:
+                        .mp3, .mp4, .wav o.s.frv.)
+                    </Form.Label>
+                    <Form.Control
+                        type={'file'}
+                        onChange={props.onAudioFilesChanged}
+                        multiple
+                    />
+                </Form.Group>
+            ) : (
+                <UrlInput
+                    label={'RSSFeed'}
+                    value={feed}
+                    placeholder={'https://hlekkurinn.is'}
+                    onChange={feedChanged}
+                />
+            )}
+        </>
+    );
+};

--- a/frontend/src/components/frontpage/index.tsx
+++ b/frontend/src/components/frontpage/index.tsx
@@ -49,23 +49,7 @@ const SubmitButton = styled.button`
     }
 `;
 
-const UploadTypeText = styled.p`
-    margin: 0;
-`;
-
-const RadioLabel = styled.label`
-    margin-left: 0.5rem;
-`;
-
 const NameInput = styled(TextInput)``;
-
-const UrlInput = styled(TextInput)`
-    margin: 1rem 0rem;
-`;
-
-const RadioButtonsContainer = styled.div`
-    margin-top: 1rem;
-`;
 
 const FilesWrapper = styled.div``;
 

--- a/frontend/src/components/frontpage/index.tsx
+++ b/frontend/src/components/frontpage/index.tsx
@@ -5,6 +5,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import TextInput from '../ui/input/text-input';
 import Layout from '../ui/layout';
 import Form from 'react-bootstrap/Form';
+import Button from 'react-bootstrap/Button';
 import Spinner from 'react-bootstrap/Spinner';
 
 import * as api from '../../services/api';
@@ -67,7 +68,9 @@ const RadioButtonsContainer = styled.div`
     margin-top: 1rem;
 `;
 
-const FilesContainer = styled.div``;
+const FilesContainer = styled.div`
+    max-height: 30rem;
+`;
 
 const FileItem = styled.div`
     display: flex;
@@ -98,6 +101,14 @@ const Remove = styled.button`
 
 const FormGroup = styled(Form.Group)`
     margin-top: 1.5rem;
+`;
+
+const FormControl = styled(Form.Control)`
+    display: none;
+`;
+
+const LargeButton = styled(Button)`
+    width: 20rem;
 `;
 
 const SelectedFilesTitle = styled.div`
@@ -323,11 +334,30 @@ class FrontPage extends React.Component<Props, State> {
                                 Veldu handrit til að hlaða upp (textaskrár á
                                 sniði: .txt, .ppt, .rtf, .docx o.s.frv.)
                             </Form.Label>
-                            <Form.Control
+                            <FormControl
                                 type={'file'}
                                 onChange={this.onFileChange}
                                 multiple
                             />
+                            <div className="d-grid">
+                                <Button
+                                    variant={
+                                        selectedFiles.length > 0
+                                            ? 'success'
+                                            : 'primary'
+                                    }
+                                    size="lg"
+                                    onClick={() =>
+                                        document
+                                            .getElementById('formFileMultiple')
+                                            ?.click()
+                                    }
+                                >
+                                    {selectedFiles.length > 0
+                                        ? 'Velja fleiri skrár'
+                                        : 'Velja skrár'}
+                                </Button>
+                            </div>
                         </FormGroup>
                         {/* might be useful for if people upload all the
                                 data as an archive
@@ -355,22 +385,24 @@ class FrontPage extends React.Component<Props, State> {
                         </SubmitButton>
                     </Form>
                     <FilesContainer>
-                        {selectedFiles && selectedFiles.length > -1 && (
+                        {selectedFiles && selectedFiles.length > 0 && (
                             <SelectedFilesTitle>
                                 <h3>Valdar skrár ({selectedFiles.length})</h3>
-                                <RemoveAllButton
+                                <Button
+                                    variant="danger"
                                     onClick={this.clearAllSelectedFiles}
                                 >
                                     Fjarlægja allar skrár
-                                </RemoveAllButton>
+                                </Button>
                             </SelectedFilesTitle>
                         )}
                         {selectedFiles &&
                             Array.from(selectedFiles).map((file) => {
                                 return (
-                                    <FileItem>
+                                    <FileItem key={file.name}>
                                         <Status>
-                                            <Remove
+                                            <Button
+                                                variant="danger"
                                                 onClick={() =>
                                                     this.removeFileClicked(
                                                         file.name
@@ -379,7 +411,7 @@ class FrontPage extends React.Component<Props, State> {
                                                 title={'Fjarlægja'}
                                             >
                                                 X
-                                            </Remove>
+                                            </Button>
                                         </Status>
                                         <Name>{file.name}</Name>
                                     </FileItem>

--- a/frontend/src/components/frontpage/index.tsx
+++ b/frontend/src/components/frontpage/index.tsx
@@ -5,7 +5,6 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import TextInput from '../ui/input/text-input';
 import Layout from '../ui/layout';
 import Form from 'react-bootstrap/Form';
-import Button from 'react-bootstrap/Button';
 import Spinner from 'react-bootstrap/Spinner';
 
 import * as api from '../../services/api';
@@ -29,11 +28,11 @@ const SubmitButton = styled.button`
     font-size: 2rem;
     height: 3.5rem;
     margin: 1rem 0rem;
-    border: 1px solid ${({ disabled }) => (disabled ? 'gray' : '#60C197')};
+    border: 1px solid ${({ disabled }) => (disabled ? 'gray' : '#29BF12')};
 
     border-radius: 0.1rem;
 
-    background-color: ${({ disabled }) => (disabled ? 'gray' : '#60C197')};
+    background-color: ${({ disabled }) => (disabled ? 'gray' : '#29BF12')};
 
     cursor: ${({ disabled }) => (disabled ? 'initial' : 'pointer')};
     &:active {
@@ -68,13 +67,30 @@ const RadioButtonsContainer = styled.div`
     margin-top: 1rem;
 `;
 
+const FilesWrapper = styled.div``;
+
 const FilesContainer = styled.div`
     max-height: 30rem;
+    overflow-y: scroll;
+    border: 1px solid lightgray;
+    padding: 0rem 0.25rem;
+`;
+
+interface SpinnerWrapperProps {
+    hidden?: boolean;
+}
+
+const SpinnerWrapper = styled.div<SpinnerWrapperProps>`
+    display: ${(props) => (props.hidden ? 'none' : 'flex')};
+    align-items: center;
+    justify-content: center;
+    margin-top: 1rem;
 `;
 
 const FileItem = styled.div`
     display: flex;
     flex-direction: row;
+    justify-content: space-between;
     gap: 1rem;
     box-shadow: 0px 2px #e2e2e2;
 `;
@@ -89,14 +105,25 @@ const Status = styled.div`
     margin-right: 0.5rem;
 `;
 
-const Remove = styled.button`
+const Button = styled.button`
     color: white;
-    background: red;
     border: none;
     font-weight: bold;
+    border-radius: 0.1rem;
+
+    :active {
+        transform: translateY(2px);
+    }
+`;
+
+const RemoveOneButton = styled(Button)`
+    background: #ff0a1f;
     border-radius: 50%;
     width: 1.5rem;
     aspect-ratio: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 `;
 
 const FormGroup = styled(Form.Group)`
@@ -107,25 +134,24 @@ const FormControl = styled(Form.Control)`
     display: none;
 `;
 
-const LargeButton = styled(Button)`
-    width: 20rem;
-`;
-
 const SelectedFilesTitle = styled.div`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
 `;
 
-const RemoveAllButton = styled.button`
-    border: none;
-    color: white;
-    background: red;
-    font-weight: bold;
+const RemoveAllButton = styled(Button)`
+    background: #ff0a1f;
+    margin-bottom: 0.5rem;
+    height: 2rem;
+`;
 
-    :active {
-        transform: translateY(2px);
-    }
+const UploadFilesButton = styled(Button)`
+    background: #2d7ff0;
+    height: 3.5rem;
+    width: 100%;
+    font-size: 2rem;
+    font-weight: normal;
 `;
 
 const WelcomeTextContainer = styled.div``;
@@ -302,6 +328,11 @@ class FrontPage extends React.Component<Props, State> {
         this.setState({ selectedFiles: [], selectedAudioFiles: [] });
     };
 
+    onSelectFilesClicked = (e: any) => {
+        e.preventDefault();
+        document.getElementById('formFileMultiple')?.click();
+    };
+
     render() {
         const { processing, audioType, selectedFiles } = this.state;
         return (
@@ -339,25 +370,13 @@ class FrontPage extends React.Component<Props, State> {
                                 onChange={this.onFileChange}
                                 multiple
                             />
-                            <div className="d-grid">
-                                <Button
-                                    variant={
-                                        selectedFiles.length > 0
-                                            ? 'success'
-                                            : 'primary'
-                                    }
-                                    size="lg"
-                                    onClick={() =>
-                                        document
-                                            .getElementById('formFileMultiple')
-                                            ?.click()
-                                    }
-                                >
-                                    {selectedFiles.length > 0
-                                        ? 'Velja fleiri skrár'
-                                        : 'Velja skrár'}
-                                </Button>
-                            </div>
+                            <UploadFilesButton
+                                onClick={this.onSelectFilesClicked}
+                            >
+                                {selectedFiles.length > 0
+                                    ? 'Velja fleiri skrár'
+                                    : 'Velja skrár'}
+                            </UploadFilesButton>
                         </FormGroup>
                         {/* might be useful for if people upload all the
                                 data as an archive
@@ -370,13 +389,58 @@ class FrontPage extends React.Component<Props, State> {
                               />
                             </Form.Group>
                             */}
-                        <Spinner
-                            animation={'border'}
-                            role={'status'}
-                            hidden={!processing}
-                        >
-                            <span className="visually-hidden">Loading...</span>
-                        </Spinner>
+                        <FilesWrapper>
+                            {selectedFiles && selectedFiles.length > 0 && (
+                                <SelectedFilesTitle>
+                                    <h3>
+                                        Valdar skrár ({selectedFiles.length})
+                                    </h3>
+                                    <RemoveAllButton
+                                        onClick={this.clearAllSelectedFiles}
+                                    >
+                                        Fjarlægja allar skrár
+                                    </RemoveAllButton>
+                                </SelectedFilesTitle>
+                            )}
+                            {selectedFiles.length > 0 && (
+                                <FilesContainer>
+                                    {Array.from(selectedFiles).map(
+                                        (file, index) => {
+                                            return (
+                                                <FileItem key={file.name}>
+                                                    <Name>{`${index + 1} - ${
+                                                        file.name
+                                                    }`}</Name>
+                                                    <Status>
+                                                        <RemoveOneButton
+                                                            onClick={() =>
+                                                                this.removeFileClicked(
+                                                                    file.name
+                                                                )
+                                                            }
+                                                            title={'Fjarlægja'}
+                                                        >
+                                                            X
+                                                        </RemoveOneButton>
+                                                    </Status>
+                                                </FileItem>
+                                            );
+                                        }
+                                    )}
+                                </FilesContainer>
+                            )}
+                        </FilesWrapper>
+                        <SpinnerWrapper hidden={!processing}>
+                            <Spinner
+                                animation={'border'}
+                                role={'status'}
+                                hidden={!processing}
+                            >
+                                <span className="visually-hidden">
+                                    Loading...
+                                </span>
+                            </Spinner>
+                        </SpinnerWrapper>
                         <SubmitButton
                             type="submit"
                             disabled={this.submitDisabled()}
@@ -384,40 +448,6 @@ class FrontPage extends React.Component<Props, State> {
                             Hlaða upp
                         </SubmitButton>
                     </Form>
-                    <FilesContainer>
-                        {selectedFiles && selectedFiles.length > 0 && (
-                            <SelectedFilesTitle>
-                                <h3>Valdar skrár ({selectedFiles.length})</h3>
-                                <Button
-                                    variant="danger"
-                                    onClick={this.clearAllSelectedFiles}
-                                >
-                                    Fjarlægja allar skrár
-                                </Button>
-                            </SelectedFilesTitle>
-                        )}
-                        {selectedFiles &&
-                            Array.from(selectedFiles).map((file) => {
-                                return (
-                                    <FileItem key={file.name}>
-                                        <Status>
-                                            <Button
-                                                variant="danger"
-                                                onClick={() =>
-                                                    this.removeFileClicked(
-                                                        file.name
-                                                    )
-                                                }
-                                                title={'Fjarlægja'}
-                                            >
-                                                X
-                                            </Button>
-                                        </Status>
-                                        <Name>{file.name}</Name>
-                                    </FileItem>
-                                );
-                            })}
-                    </FilesContainer>
                 </FrontPageContainer>
             </Layout>
         );


### PR DESCRIPTION
This show the current selected files for upload. 
You can remove any file you don't want to upload before clicking upload. 
You can select more files by clicking the select files button again which gets updated text to "Choose more files"

This PR also moves the Audio parts into its own component and hides it for now. Since most podcasters do not have access to the files anyway. So more in line with your initial thinking.

I am not sure about the UI design for this, but here is how it looks.

![image](https://user-images.githubusercontent.com/72071258/176183210-56537ac0-5c54-4a6f-9cd2-0154a461ccd1.png)
